### PR TITLE
Move the site base name back to root.

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "hr",
     "version": "0.1.0",
     "private": true,
-    "homepage": "https://yman.dev/hr",
+    "homepage": "https://hr.yman.dev",
     "dependencies": {
         "@material-ui/core": "^4.11.0",
         "@material-ui/icons": "^4.9.1",

--- a/src/index.js
+++ b/src/index.js
@@ -6,7 +6,7 @@ import * as serviceWorker from './serviceWorker';
 import { BrowserRouter } from 'react-router-dom';
 
 ReactDOM.render(
-  <BrowserRouter basename={'/hr'}>
+  <BrowserRouter basename={'/'}>
    <React.StrictMode>
       <App />
     </React.StrictMode>


### PR DESCRIPTION
I had to do this in order to move the public site to `hr.{domain}`.