### PR TITLE
Replace BrowserRouter with HashRouter.

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -3,14 +3,14 @@ import ReactDOM from 'react-dom';
 import './index.css';
 import App from './App';
 import * as serviceWorker from './serviceWorker';
-import { BrowserRouter } from 'react-router-dom';
+import { HashRouter } from 'react-router-dom';
 
 ReactDOM.render(
-  <BrowserRouter basename={'/'}>
-   <React.StrictMode>
-      <App />
+  <HashRouter basename={'/'}>
+    <React.StrictMode>
+        <App/>
     </React.StrictMode>
-  </BrowserRouter>,
+  </HashRouter>,
   document.getElementById('root')
 );
 


### PR DESCRIPTION
I had to replace BrowserRouter with HashRouter so the app will work correctly on my web server. With BrowserRouter, when going to the employees page for example and hitting refresh, the web server's 404 error page would show up. The web app works correctly with HashRouter though!